### PR TITLE
Add registration form with room arrangement fields

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
         
       - name: Build
         run: npm run build
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
         
       - name: Create .nojekyll file
         run: touch build/.nojekyll

--- a/src/lib/components/PriceSummary.svelte
+++ b/src/lib/components/PriceSummary.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import {
+		BASE_FEES,
+		ADDON_SUMMER_SCHOOL,
+		ADDON_CONFERENCE_DINNER,
+		getCurrentTier,
+		formatPrice,
+		CATEGORIES
+	} from '$lib/config/registration';
+
+	let {
+		category,
+		summerSchool,
+		conferenceDinner
+	}: {
+		category: string;
+		summerSchool: boolean;
+		conferenceDinner: boolean;
+	} = $props();
+
+	let tier = $derived(getCurrentTier());
+
+	let categoryLabel = $derived(
+		CATEGORIES.find((c) => c.value === category)?.label ?? 'Select category'
+	);
+
+	let tierLabel = $derived(
+		tier === 'early_bird' ? 'Early Bird' : tier === 'regular' ? 'Regular' : 'On-Site'
+	);
+
+	let baseFee = $derived(category ? (BASE_FEES[category]?.[tier] ?? 0) : 0);
+
+	let summerSchoolFee = $derived(summerSchool ? ADDON_SUMMER_SCHOOL : 0);
+	let dinnerFee = $derived(conferenceDinner ? ADDON_CONFERENCE_DINNER : 0);
+
+	let total = $derived(baseFee + summerSchoolFee + dinnerFee);
+</script>
+
+<div class="card bg-base-200 shadow-sm">
+	<div class="card-body">
+		<h3 class="card-title text-lg">Estimated Price Summary</h3>
+		<p class="text-xs text-base-content/60 mb-2">
+			Current tier: <span class="font-semibold">{tierLabel}</span> — final price calculated at checkout
+		</p>
+
+		<div class="space-y-2 text-sm">
+			{#if baseFee > 0}
+				<div class="flex justify-between">
+					<span>Registration ({categoryLabel}, {tierLabel})</span>
+					<span class="font-mono">{formatPrice(baseFee)}</span>
+				</div>
+			{/if}
+
+			{#if summerSchoolFee > 0}
+				<div class="flex justify-between">
+					<span>Summer School</span>
+					<span class="font-mono">{formatPrice(summerSchoolFee)}</span>
+				</div>
+			{/if}
+
+			{#if dinnerFee > 0}
+				<div class="flex justify-between">
+					<span>Conference Dinner</span>
+					<span class="font-mono">{formatPrice(dinnerFee)}</span>
+				</div>
+			{/if}
+
+			<div class="divider my-1"></div>
+
+			<div class="flex justify-between text-base font-bold">
+				<span>Total</span>
+				<span class="font-mono">{total > 0 ? formatPrice(total) : '—'}</span>
+			</div>
+
+			<p class="text-xs text-base-content/60 mt-2">
+				Note: Hall accommodation fees (if applicable) are payable by cash upon arrival.
+			</p>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/RegistrationForm.svelte
+++ b/src/lib/components/RegistrationForm.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+	import PriceSummary from './PriceSummary.svelte';
+	import {
+		API_BASE_URL,
+		CATEGORIES,
+		CATERING_OPTIONS,
+		ROOM_TYPES,
+		GENDER_OPTIONS
+	} from '$lib/config/registration';
+
+	// Form state
+	let name = $state('');
+	let email = $state('');
+	let institution = $state('');
+	let category = $state('');
+	let abstractTitle = $state('');
+	let summerSchool = $state(false);
+	let conferenceDinner = $state(false);
+	let roomType = $state('none');
+	let gender = $state('');
+	let roommate = $state('');
+	let catering = $state('no_preference');
+	let dietaryNotes = $state('');
+
+	let showDietaryNotes = $derived(catering === 'allergy' || catering === 'other');
+	let needsHall = $derived(roomType !== 'none');
+	let isDouble = $derived(roomType === 'double');
+
+	let submitting = $state(false);
+	let error = $state('');
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+
+		try {
+			const response = await fetch(`${API_BASE_URL}/api/create-checkout`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					name,
+					email,
+					institution,
+					category,
+					abstract_title: abstractTitle,
+					summer_school: summerSchool,
+					conference_dinner: conferenceDinner,
+					room_type: roomType,
+					gender: needsHall ? gender : '',
+					roommate: isDouble ? roommate : '',
+					catering,
+					dietary_notes: dietaryNotes
+				})
+			});
+
+			if (!response.ok) {
+				const data = await response.json().catch(() => null);
+				throw new Error(data?.detail?.[0]?.msg ?? data?.detail ?? 'Registration failed. Please try again.');
+			}
+
+			const { checkout_url } = await response.json();
+			window.location.href = checkout_url;
+		} catch (err: any) {
+			error = err.message || 'Something went wrong. Please try again.';
+			submitting = false;
+		}
+	}
+</script>
+
+<form onsubmit={handleSubmit} class="space-y-8">
+	<!-- Personal Information -->
+	<div>
+		<h3 class="text-2xl font-bold mb-4">Personal Information</h3>
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+			<label class="form-control w-full">
+				<div class="label"><span class="label-text">Full Name *</span></div>
+				<input
+					type="text"
+					bind:value={name}
+					required
+					maxlength="200"
+					class="input input-bordered w-full"
+					placeholder="Your full name"
+				/>
+			</label>
+
+			<label class="form-control w-full">
+				<div class="label"><span class="label-text">Email *</span></div>
+				<input
+					type="email"
+					bind:value={email}
+					required
+					class="input input-bordered w-full"
+					placeholder="your@email.com"
+				/>
+			</label>
+
+			<label class="form-control w-full">
+				<div class="label"><span class="label-text">Institution / Affiliation *</span></div>
+				<input
+					type="text"
+					bind:value={institution}
+					required
+					maxlength="300"
+					class="input input-bordered w-full"
+					placeholder="University or organization"
+				/>
+			</label>
+
+			<label class="form-control w-full">
+				<div class="label"><span class="label-text">Category *</span></div>
+				<select bind:value={category} required class="select select-bordered w-full">
+					<option value="" disabled>Select your category</option>
+					{#each CATEGORIES as cat}
+						<option value={cat.value}>{cat.label}</option>
+					{/each}
+				</select>
+			</label>
+		</div>
+	</div>
+
+	<!-- Conference Options -->
+	<div>
+		<h3 class="text-2xl font-bold mb-4">Conference Options</h3>
+		<div class="space-y-4">
+			<label class="form-control w-full">
+				<div class="label"><span class="label-text">Abstract Title (if applicable)</span></div>
+				<input
+					type="text"
+					bind:value={abstractTitle}
+					maxlength="500"
+					class="input input-bordered w-full"
+					placeholder="Title of your submitted abstract"
+				/>
+			</label>
+
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<label class="label cursor-pointer justify-start gap-3 p-4 bg-base-200 rounded-lg">
+					<input type="checkbox" bind:checked={summerSchool} class="checkbox checkbox-primary" />
+					<div>
+						<span class="label-text font-medium">Summer School Attendance</span>
+						<p class="text-xs text-base-content/60">+S$50 (covers coffee breaks and lunches)</p>
+					</div>
+				</label>
+
+				<label class="label cursor-pointer justify-start gap-3 p-4 bg-base-200 rounded-lg">
+					<input
+						type="checkbox"
+						bind:checked={conferenceDinner}
+						class="checkbox checkbox-primary"
+					/>
+					<div>
+						<span class="label-text font-medium">Conference Dinner</span>
+						<p class="text-xs text-base-content/60">+S$50</p>
+					</div>
+				</label>
+			</div>
+
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<label class="form-control w-full">
+					<div class="label"><span class="label-text">Catering Preference</span></div>
+					<select bind:value={catering} class="select select-bordered w-full">
+						{#each CATERING_OPTIONS as opt}
+							<option value={opt.value}>{opt.label}</option>
+						{/each}
+					</select>
+				</label>
+			</div>
+
+			{#if showDietaryNotes}
+				<label class="form-control w-full">
+					<div class="label"><span class="label-text">Please specify your dietary requirements / allergies</span></div>
+					<textarea
+						bind:value={dietaryNotes}
+						maxlength="500"
+						rows="2"
+						class="textarea textarea-bordered w-full"
+						placeholder="e.g. allergic to prawns and beef"
+					></textarea>
+					<div class="label">
+						<span class="label-text-alt">{dietaryNotes.length}/500 characters</span>
+					</div>
+				</label>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Hall Accommodation -->
+	<div>
+		<h3 class="text-2xl font-bold mb-4">Hall Accommodation</h3>
+		<div class="alert alert-info mb-4">
+			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+			<span>Hall accommodation fees are to be paid by cash upon arrival. This section is for room arrangement purposes only.</span>
+		</div>
+		<div class="space-y-4">
+			<label class="form-control w-full">
+				<div class="label"><span class="label-text">Room Type</span></div>
+				<select bind:value={roomType} class="select select-bordered w-full">
+					{#each ROOM_TYPES as rt}
+						<option value={rt.value}>{rt.label}</option>
+					{/each}
+				</select>
+			</label>
+
+			{#if needsHall}
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<label class="form-control w-full">
+						<div class="label"><span class="label-text">Gender *</span></div>
+						<select bind:value={gender} required class="select select-bordered w-full">
+							<option value="" disabled>Select gender</option>
+							{#each GENDER_OPTIONS as g}
+								<option value={g.value}>{g.label}</option>
+							{/each}
+						</select>
+					</label>
+
+					{#if isDouble}
+						<label class="form-control w-full">
+							<div class="label"><span class="label-text">Preferred Roommate</span></div>
+							<input
+								type="text"
+								bind:value={roommate}
+								maxlength="200"
+								class="input input-bordered w-full"
+								placeholder="Name of preferred roommate (if any)"
+							/>
+						</label>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Price Summary -->
+	<PriceSummary {category} {summerSchool} {conferenceDinner} />
+
+	<!-- Error message -->
+	{#if error}
+		<div class="alert alert-error">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				class="stroke-current shrink-0 h-6 w-6"
+				fill="none"
+				viewBox="0 0 24 24"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+				/>
+			</svg>
+			<span>{error}</span>
+		</div>
+	{/if}
+
+	<!-- Submit -->
+	<button type="submit" class="btn btn-primary btn-lg w-full" disabled={submitting}>
+		{#if submitting}
+			<span class="loading loading-spinner"></span>
+			Redirecting to payment...
+		{:else}
+			Proceed to Payment
+		{/if}
+	</button>
+</form>

--- a/src/lib/config/registration.ts
+++ b/src/lib/config/registration.ts
@@ -1,0 +1,65 @@
+/**
+ * Registration pricing constants (mirror of backend, for display only).
+ * The backend always recalculates server-side — these are only for the form UI.
+ */
+
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8787';
+
+export const CURRENCY = 'SGD';
+
+export const CATEGORIES = [
+	{ value: 'student', label: 'PhD/UG Student' },
+	{ value: 'postdoc', label: 'Postdoc' },
+	{ value: 'academic', label: 'Academic' },
+	{ value: 'industry', label: 'Government & Industry' }
+] as const;
+
+export const CATERING_OPTIONS = [
+	{ value: 'no_preference', label: 'No Preference' },
+	{ value: 'vegetarian', label: 'Vegetarian' },
+	{ value: 'halal', label: 'Halal' },
+	{ value: 'allergy', label: 'Allergy' },
+	{ value: 'other', label: 'Other' }
+] as const;
+
+/** Base fees in cents, keyed by category then tier */
+export const BASE_FEES: Record<string, Record<string, number>> = {
+	student: { early_bird: 15000, regular: 20000, on_site: 30000 },
+	postdoc: { early_bird: 20000, regular: 30000, on_site: 50000 },
+	academic: { early_bird: 30000, regular: 50000, on_site: 80000 },
+	industry: { early_bird: 50000, regular: 70000, on_site: 100000 }
+};
+
+export const ADDON_SUMMER_SCHOOL = 5000; // S$50
+export const ADDON_CONFERENCE_DINNER = 5000; // S$50
+
+export const ROOM_TYPES = [
+	{ value: 'none', label: 'No accommodation needed' },
+	{ value: 'single', label: 'Single Room' },
+	{ value: 'double', label: 'Double Room (Twin Sharing)' }
+] as const;
+
+export const GENDER_OPTIONS = [
+	{ value: 'male', label: 'Male' },
+	{ value: 'female', label: 'Female' }
+] as const;
+
+/** Determine current tier from today's date (for display estimate only). */
+export function getCurrentTier(): string {
+	// Use Singapore time (UTC+8) for tier calculation
+	const now = new Date();
+	const sgtString = now.toLocaleDateString('en-CA', { timeZone: 'Asia/Singapore' });
+	const today = new Date(sgtString);
+
+	const earlyBirdEnd = new Date('2026-04-30');
+	const regularEnd = new Date('2026-05-31');
+
+	if (today <= earlyBirdEnd) return 'early_bird';
+	if (today <= regularEnd) return 'regular';
+	return 'on_site';
+}
+
+/** Format cents as SGD display string. */
+export function formatPrice(cents: number): string {
+	return `S$${(cents / 100).toFixed(0)}`;
+}

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -74,7 +74,7 @@
 		</div>
 	</section>
 
-	<section class="py-16 px-4 bg-base-200">
+	<section class="py-16 px-4">
 		<div class="max-w-4xl mx-auto">
 			<h2 class="text-3xl font-bold text-center mb-8">Important Dates</h2>
 			<div class="overflow-x-auto">

--- a/src/routes/registration/cancel/+page.svelte
+++ b/src/routes/registration/cancel/+page.svelte
@@ -1,0 +1,26 @@
+<svelte:head>
+	<title>Registration Cancelled - APCNCS 2026</title>
+	<meta name="description" content="Your registration payment was cancelled." />
+</svelte:head>
+
+<div class="min-h-screen">
+	<section class="py-24 px-4">
+		<div class="max-w-2xl mx-auto text-center">
+			<div class="mb-8">
+				<svg xmlns="http://www.w3.org/2000/svg" class="h-24 w-24 text-warning mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+				</svg>
+			</div>
+
+			<h1 class="text-4xl font-bold mb-4">Payment Cancelled</h1>
+			<p class="text-lg text-base-content/70 mb-8">
+				Your payment was not processed. No charges have been made. You can try registering again whenever you're ready.
+			</p>
+
+			<div class="flex gap-4 justify-center">
+				<a href="/registration" class="btn btn-primary">Try Again</a>
+				<a href="/" class="btn btn-outline">Back to Home</a>
+			</div>
+		</div>
+	</section>
+</div>

--- a/src/routes/registration/form/+page.svelte
+++ b/src/routes/registration/form/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { getHeroBackgroundStyle } from '$lib/config/heroImages';
+	import RegistrationForm from '$lib/components/RegistrationForm.svelte';
+</script>
+
+<svelte:head>
+	<title>Register - APCNCS 2026</title>
+	<meta name="description" content="Register for the Asia-Pacific Summer School and Conference on Networks and Complex Systems">
+</svelte:head>
+
+<div class="min-h-screen">
+	<section class="hero hero-bg hero-page" style={getHeroBackgroundStyle('registration')}>
+		<div class="hero-content text-center hero-content-overlay">
+			<div class="max-w-4xl">
+				<h1 class="text-5xl font-bold hero-text mb-4">Registration Form</h1>
+				<p class="text-xl hero-text-secondary">APCNCS 2026</p>
+			</div>
+		</div>
+	</section>
+
+	<section class="py-16 px-4">
+		<div class="max-w-4xl mx-auto">
+			<RegistrationForm />
+		</div>
+	</section>
+</div>

--- a/src/routes/registration/success/+page.svelte
+++ b/src/routes/registration/success/+page.svelte
@@ -1,0 +1,38 @@
+<svelte:head>
+	<title>Registration Successful - APCNCS 2026</title>
+	<meta name="description" content="Your registration for APCNCS 2026 has been completed successfully." />
+</svelte:head>
+
+<div class="min-h-screen">
+	<section class="py-24 px-4">
+		<div class="max-w-2xl mx-auto text-center">
+			<div class="mb-8">
+				<svg xmlns="http://www.w3.org/2000/svg" class="h-24 w-24 text-success mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+				</svg>
+			</div>
+
+			<h1 class="text-4xl font-bold mb-4">Registration Successful!</h1>
+			<p class="text-lg text-base-content/70 mb-8">
+				Thank you for registering for APCNCS 2026. A confirmation email will be sent to you shortly with your registration details.
+			</p>
+
+			<div class="card bg-base-200 mb-8">
+				<div class="card-body text-left">
+					<h2 class="card-title">What's Next?</h2>
+					<ul class="list-disc list-inside space-y-2 text-base-content/80">
+						<li>Check your email for the payment receipt from Stripe</li>
+						<li>You'll receive a confirmation email with your registration details</li>
+						<li>If you submitted an abstract, you'll be notified of acceptance separately</li>
+						<li>Check the <a href="/programme" class="link link-primary">programme</a> for schedule updates</li>
+					</ul>
+				</div>
+			</div>
+
+			<div class="flex gap-4 justify-center">
+				<a href="/" class="btn btn-primary">Back to Home</a>
+				<a href="/programme" class="btn btn-outline">View Programme</a>
+			</div>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Registration form with Stripe checkout integration
- Hall accommodation fields (room type, gender, roommate) for arrangement only — no online charge, paid by cash on arrival
- Registration link intentionally hidden — form accessible at `/registration/form` for preview

## Test plan
- [ ] Visit `/registration/form` directly and verify form renders
- [ ] Verify hall section shows room type, gender (when room selected), roommate (when double)
- [ ] Verify price summary does NOT include hall fees
- [ ] Confirm no "Register Now" link on `/registration` page