### PR TITLE
Add Register Now link to registration page

### DIFF
--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -74,6 +74,12 @@
 		</div>
 	</section>
 
+	<section class="py-16 px-4 bg-base-200">
+		<div class="max-w-4xl mx-auto text-center">
+			<a href="/registration/form" class="btn btn-primary btn-lg">Register Now</a>
+		</div>
+	</section>
+
 	<section class="py-16 px-4">
 		<div class="max-w-4xl mx-auto">
 			<h2 class="text-3xl font-bold text-center mb-8">Important Dates</h2>


### PR DESCRIPTION
## Summary
- Adds the public "Register Now" button linking to `/registration/form`
- Merge this PR when registration officially opens

## Test plan
- [ ] Verify "Register Now" button appears on `/registration` page
- [ ] Verify it links to `/registration/form`

> **Note:** Merge PR #2 first before merging this one.