### PR TITLE
Add Sarah Russell talk title to programme schedule

### DIFF
--- a/src/lib/data/programme.ts
+++ b/src/lib/data/programme.ts
@@ -120,7 +120,7 @@ export const days: DayData[] = [
 			{ startMin: 180, endMin: 270, title: 'Parallel Session 1', type: 'parallel', timeLabel: '11:00 – 12:30' },
 			{ startMin: 270, endMin: 330, title: 'Lunch', type: 'break', timeLabel: '12:30 – 13:30' },
 			{ startMin: 330, endMin: 360, title: 'Lock Yue Chew', type: 'talk', timeLabel: '13:30 – 14:00' },
-			{ startMin: 360, endMin: 390, title: 'Sarah Russell', type: 'talk', timeLabel: '14:00 – 14:30' },
+			{ startMin: 360, endMin: 390, title: 'Sarah Russell', subtitle: 'T cell development: Coordinated self-organisation at the level of the cell, the organ and the body', type: 'talk', timeLabel: '14:00 – 14:30' },
 			{ startMin: 390, endMin: 420, title: 'Thiparat Chotibut', subtitle: 'Robust Sequence Recognition in Random Neuronal Networks', type: 'talk', timeLabel: '14:30 – 15:00' },
 			{ startMin: 420, endMin: 450, title: 'Marton Karsai', subtitle: 'EiC, Advances in Complex Systems', type: 'editor', timeLabel: '15:00 – 15:30' },
 			{ startMin: 450, endMin: 480, title: 'Coffee Break', type: 'break', timeLabel: '15:30 – 16:00' },

--- a/src/lib/data/programmeDetail.ts
+++ b/src/lib/data/programmeDetail.ts
@@ -154,7 +154,7 @@ export const dayDetails: DayDetail[] = [
 				location: 'SPMS-LT1',
 				talks: [
 					{ time: '13:30 – 14:00', speaker: 'Lock Yue Chew (NTU, Singapore)', title: 'TBC' },
-					{ time: '14:00 – 14:30', speaker: 'Sarah Russell (Peter MacCallum Cancer Centre & Swinburne University of Technology, Australia)', title: 'TBC' },
+					{ time: '14:00 – 14:30', speaker: 'Sarah Russell (Peter MacCallum Cancer Centre & Swinburne University of Technology, Australia)', title: 'T cell development: Coordinated self-organisation at the level of the cell, the organ and the body' },
 					{ time: '14:30 – 15:00', speaker: 'Thiparat Chotibut (Chulalongkorn University, Thailand)', title: 'Robust Sequence Recognition in Random Neuronal Networks' },
 					{
 						time: '15:00 – 15:30',


### PR DESCRIPTION
## Summary
Updated the programme schedule to include the talk title for Sarah Russell's presentation, which was previously marked as "TBC" (To Be Confirmed).

## Changes
- Added subtitle to Sarah Russell's talk entry in the main programme schedule (`programme.ts`): "T cell development: Coordinated self-organisation at the level of the cell, the organ and the body"
- Updated the corresponding detailed programme entry (`programmeDetail.ts`) to replace the placeholder "TBC" title with the actual talk title

## Details
The changes ensure consistency across both the main programme view and the detailed programme information, providing attendees with the complete talk title for the 14:00 – 14:30 session on the first day.

https://claude.ai/code/session_01NCQz4kFWBmMYot2fecK8RW