### PR TITLE
Update Lock Yue Chew's invited talk title

### DIFF
--- a/src/lib/data/programme.ts
+++ b/src/lib/data/programme.ts
@@ -119,7 +119,7 @@ export const days: DayData[] = [
 			{ startMin: 150, endMin: 180, title: 'Coffee Break', type: 'break', timeLabel: '10:30 – 11:00' },
 			{ startMin: 180, endMin: 270, title: 'Parallel Session 1', type: 'parallel', timeLabel: '11:00 – 12:30' },
 			{ startMin: 270, endMin: 330, title: 'Lunch', type: 'break', timeLabel: '12:30 – 13:30' },
-			{ startMin: 330, endMin: 360, title: 'Lock Yue Chew', type: 'talk', timeLabel: '13:30 – 14:00' },
+			{ startMin: 330, endMin: 360, title: 'Lock Yue Chew', subtitle: 'Dynamical scheduling and statistical physics of city-scale bus network with reinforcement learning', type: 'talk', timeLabel: '13:30 – 14:00' },
 			{ startMin: 360, endMin: 390, title: 'Sarah Russell', subtitle: 'T cell development: Coordinated self-organisation at the level of the cell, the organ and the body', type: 'talk', timeLabel: '14:00 – 14:30' },
 			{ startMin: 390, endMin: 420, title: 'Thiparat Chotibut', subtitle: 'Robust Sequence Recognition in Random Neuronal Networks', type: 'talk', timeLabel: '14:30 – 15:00' },
 			{ startMin: 420, endMin: 450, title: 'Marton Karsai', subtitle: 'EiC, Advances in Complex Systems', type: 'editor', timeLabel: '15:00 – 15:30' },

--- a/src/lib/data/programmeDetail.ts
+++ b/src/lib/data/programmeDetail.ts
@@ -153,7 +153,7 @@ export const dayDetails: DayDetail[] = [
 				time: '13:30 – 15:30',
 				location: 'SPMS-LT1',
 				talks: [
-					{ time: '13:30 – 14:00', speaker: 'Lock Yue Chew (NTU, Singapore)', title: 'TBC' },
+					{ time: '13:30 – 14:00', speaker: 'Lock Yue Chew (NTU, Singapore)', title: 'Dynamical scheduling and statistical physics of city-scale bus network with reinforcement learning' },
 					{ time: '14:00 – 14:30', speaker: 'Sarah Russell (Peter MacCallum Cancer Centre & Swinburne University of Technology, Australia)', title: 'T cell development: Coordinated self-organisation at the level of the cell, the organ and the body' },
 					{ time: '14:30 – 15:00', speaker: 'Thiparat Chotibut (Chulalongkorn University, Thailand)', title: 'Robust Sequence Recognition in Random Neuronal Networks' },
 					{


### PR DESCRIPTION
Updates Lock Yue Chew's invited talk title in both the programme overview and detail pages.

- **Lock Yue Chew** (NTU, Singapore): "Dynamical scheduling and statistical physics of city-scale bus network with reinforcement learning"

Files updated:
- `src/lib/data/programme.ts`
- `src/lib/data/programmeDetail.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCQz4kFWBmMYot2fecK8RW)_