### PR TITLE
Add other hotels near NTU to accommodation page

### DIFF
--- a/src/lib/data/hotels.ts
+++ b/src/lib/data/hotels.ts
@@ -1,0 +1,40 @@
+export interface Hotel {
+	id: string;
+	name: string;
+	subtitle?: string;
+	distance: string;
+	description: string;
+	url?: string;
+}
+
+export const otherHotels: Hotel[] = [
+	{
+		id: "four-points-jurong",
+		name: "Four Points by Sheraton Jurong",
+		subtitle: "formerly Genting Hotel Jurong",
+		distance: "~6.5 km (15 mins by taxi / 30 mins by public transport)",
+		description:
+			"Conveniently located near the Jurong East MRT interchange and major shopping malls (JEM, Westgate, and IMM), offering a wide variety of dining and retail options."
+	},
+	{
+		id: "park-avenue-rochester",
+		name: "Park Avenue Rochester",
+		distance: "~12.5 km (20 mins by taxi / 45 mins by MRT)",
+		description:
+			"Surrounded by the beautiful Rochester Park and the Star Vista mall. This area is known for its excellent selection of restaurants and cafes set in colonial bungalows."
+	},
+	{
+		id: "citadines-connect-rochester",
+		name: "Citadines Connect Rochester Singapore",
+		distance: "~12.5 km (20 mins by taxi / 45 mins by MRT)",
+		description:
+			"Offers \"Recharge\" rooms for early arrivals or late departures. It is highly integrated with the surrounding dining scene in the Buona Vista tech-corridor."
+	},
+	{
+		id: "quay-hotel-west-coast",
+		name: "The Quay Hotel West Coast",
+		distance: "~11 km (15 mins by taxi / 40 mins by bus)",
+		description:
+			"Located near West Coast Park and the National University of Singapore (NUS). It is a quieter option for those looking for a more residential feel while remaining relatively close to NTU."
+	}
+];

--- a/src/routes/accommodation/+page.svelte
+++ b/src/routes/accommodation/+page.svelte
@@ -46,6 +46,52 @@
 					<Icon name="info" class_="stroke-current shrink-0 h-6 w-6" />
 					<span>We will provide more updates as information becomes available.</span>
 				</div>
+
+				<h2 class="text-3xl font-bold mb-8 mt-12">Other Hotels Near NTU</h2>
+
+				<p class="mb-8">
+					Participants are also welcome to explore other hotels near to NTU. These are:
+				</p>
+
+				<div class="card bg-base-200 mb-6">
+					<div class="card-body">
+						<h3 class="card-title text-primary">Four Points by Sheraton Jurong (formerly Genting Hotel Jurong)</h3>
+						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~6.5 km (15 mins by taxi / 30 mins by public transport)</p>
+						<p>
+							Conveniently located near the Jurong East MRT interchange and major shopping malls (JEM, Westgate, and IMM), offering a wide variety of dining and retail options.
+						</p>
+					</div>
+				</div>
+
+				<div class="card bg-base-200 mb-6">
+					<div class="card-body">
+						<h3 class="card-title text-primary">Park Avenue Rochester</h3>
+						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~12.5 km (20 mins by taxi / 45 mins by MRT)</p>
+						<p>
+							Surrounded by the beautiful Rochester Park and the Star Vista mall. This area is known for its excellent selection of restaurants and cafes set in colonial bungalows.
+						</p>
+					</div>
+				</div>
+
+				<div class="card bg-base-200 mb-6">
+					<div class="card-body">
+						<h3 class="card-title text-primary">Citadines Connect Rochester Singapore</h3>
+						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~12.5 km (20 mins by taxi / 45 mins by MRT)</p>
+						<p>
+							Offers "Recharge" rooms for early arrivals or late departures. It is highly integrated with the surrounding dining scene in the Buona Vista tech-corridor.
+						</p>
+					</div>
+				</div>
+
+				<div class="card bg-base-200 mb-6">
+					<div class="card-body">
+						<h3 class="card-title text-primary">The Quay Hotel West Coast</h3>
+						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~11 km (15 mins by taxi / 40 mins by bus)</p>
+						<p>
+							Located near West Coast Park and the National University of Singapore (NUS). It is a quieter option for those looking for a more residential feel while remaining relatively close to NTU.
+						</p>
+					</div>
+				</div>
 			</div>
 		</div>
 	</section>

--- a/src/routes/accommodation/+page.svelte
+++ b/src/routes/accommodation/+page.svelte
@@ -2,6 +2,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import Link from '$lib/components/Link.svelte';
 	import { getHeroBackgroundStyle } from '$lib/config/heroImages';
+	import { otherHotels } from '$lib/data/hotels';
 </script>
 
 <svelte:head>
@@ -42,55 +43,32 @@
 					</div>
 				</div>
 
-				<div class="alert alert-info">
-					<Icon name="info" class_="stroke-current shrink-0 h-6 w-6" />
-					<span>We will provide more updates as information becomes available.</span>
-				</div>
-
 				<h2 class="text-3xl font-bold mb-8 mt-12">Other Hotels Near NTU</h2>
 
 				<p class="mb-8">
 					Participants are also welcome to explore other hotels near to NTU. These are:
 				</p>
 
-				<div class="card bg-base-200 mb-6">
-					<div class="card-body">
-						<h3 class="card-title text-primary">Four Points by Sheraton Jurong (formerly Genting Hotel Jurong)</h3>
-						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~6.5 km (15 mins by taxi / 30 mins by public transport)</p>
-						<p>
-							Conveniently located near the Jurong East MRT interchange and major shopping malls (JEM, Westgate, and IMM), offering a wide variety of dining and retail options.
-						</p>
+				{#each otherHotels as hotel (hotel.id)}
+					<div class="card bg-base-200 mb-6">
+						<div class="card-body">
+							<h3 class="card-title text-primary">
+								{#if hotel.url}
+									<Link href={hotel.url} text={hotel.name} />
+								{:else}
+									{hotel.name}
+								{/if}
+								{#if hotel.subtitle} ({hotel.subtitle}){/if}
+							</h3>
+							<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> {hotel.distance}</p>
+							<p>{hotel.description}</p>
+						</div>
 					</div>
-				</div>
+				{/each}
 
-				<div class="card bg-base-200 mb-6">
-					<div class="card-body">
-						<h3 class="card-title text-primary">Park Avenue Rochester</h3>
-						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~12.5 km (20 mins by taxi / 45 mins by MRT)</p>
-						<p>
-							Surrounded by the beautiful Rochester Park and the Star Vista mall. This area is known for its excellent selection of restaurants and cafes set in colonial bungalows.
-						</p>
-					</div>
-				</div>
-
-				<div class="card bg-base-200 mb-6">
-					<div class="card-body">
-						<h3 class="card-title text-primary">Citadines Connect Rochester Singapore</h3>
-						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~12.5 km (20 mins by taxi / 45 mins by MRT)</p>
-						<p>
-							Offers "Recharge" rooms for early arrivals or late departures. It is highly integrated with the surrounding dining scene in the Buona Vista tech-corridor.
-						</p>
-					</div>
-				</div>
-
-				<div class="card bg-base-200 mb-6">
-					<div class="card-body">
-						<h3 class="card-title text-primary">The Quay Hotel West Coast</h3>
-						<p class="text-sm opacity-80"><strong>Distance from NTU:</strong> ~11 km (15 mins by taxi / 40 mins by bus)</p>
-						<p>
-							Located near West Coast Park and the National University of Singapore (NUS). It is a quieter option for those looking for a more residential feel while remaining relatively close to NTU.
-						</p>
-					</div>
+				<div class="alert alert-info">
+					<Icon name="info" class_="stroke-current shrink-0 h-6 w-6" />
+					<span>We will provide more updates as information becomes available.</span>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Adds an "Other Hotels Near NTU" section to the accommodation page, listing four nearby hotels with distances and brief descriptions:

- Four Points by Sheraton Jurong (formerly Genting Hotel Jurong)
- Park Avenue Rochester
- Citadines Connect Rochester Singapore
- The Quay Hotel West Coast

File updated:
- `src/routes/accommodation/+page.svelte`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCQz4kFWBmMYot2fecK8RW)_