### PR TITLE
Update focus session name, accommodation halls, and contact page

### DIFF
--- a/src/lib/data/programmeDetail.ts
+++ b/src/lib/data/programmeDetail.ts
@@ -297,7 +297,7 @@ export const dayDetails: DayDetail[] = [
 						]
 					},
 					{
-						name: 'Focus Session on Evolutionary Games',
+						name: 'Focus Session on Games on Complex Systems',
 						location: 'MAS Executive Classroom 1',
 						tba: true,
 						talks: []
@@ -361,7 +361,7 @@ export const dayDetails: DayDetail[] = [
 						]
 					},
 					{
-						name: 'Focus Session on Evolutionary Games',
+						name: 'Focus Session on Games on Complex Systems',
 						location: 'MAS Executive Classroom 1',
 						tba: true,
 						talks: []

--- a/src/routes/accommodation/+page.svelte
+++ b/src/routes/accommodation/+page.svelte
@@ -38,7 +38,7 @@
 					<div class="card-body">
 						<h3 class="card-title text-primary">Dormitory Accommodation for Students and Postdocs</h3>
 						<p>
-							Because the conference falls within our university's summer vacation, we have also arranged for up to 150 student and postdoc participants to be hosted in single and twin-sharing rooms across multiple dormitories on campus. We hope the affordable daily rates within this arrangement will encourage more students and postdocs to participate in the conference.
+							Because the conference falls within our university's summer vacation, we have also arranged for up to 150 student and postdoc participants to be hosted in single and twin-sharing rooms at <strong>Hall 10</strong> and <strong>Hall 11</strong> on campus. We hope the affordable daily rates within this arrangement will encourage more students and postdocs to participate in the conference.
 						</p>
 					</div>
 				</div>

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -25,7 +25,6 @@
 			<h2 class="text-4xl font-bold text-center mb-12">Contact</h2>
 			<div class="prose prose-lg max-w-none">
 				<p>For inquiries about APCNCS 2026, please contact the organizing committee.</p>
-				<p>Further contact details will be provided soon.</p>
 				<p>Email: <Email email="SPMS-APCNCS2026@ntu.edu.sg" /></p>
 			</div>
 		</div>


### PR DESCRIPTION
@
Addresses jotted notes from the organizer.

## Changes
- **Focus session rename** — `Focus Session on Evolutionary Games` → `Focus Session on Games on Complex Systems` (Thursday parallel sessions 3 & 4, `programmeDetail.ts`).
- **Accommodation** — the student/postdoc dormitory section now names the specific halls: **Hall 10** and **Hall 11** (previously "multiple dormitories on campus").
- **Contact page** — removed the placeholder line "Further contact details will be provided soon."

## Notes still open (not changed here)
- **Summer school** — no updated source content was provided, so the Tuesday 9 June summer-school schedule is left as-is. Happy to update once details are available.
- **Google Maps screenshot** — no map is currently embedded anywhere on the site. A static screenshot of Google Maps risks violating Google's Terms; the supported approach is the official **"Embed a map"** iframe (free, ToS-compliant). Let me know if you want a venue map added that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@