### PR TITLE
Add 9 June Summer School day with downloadable abstract + sync tests

### DIFF
--- a/src/lib/components/DayProgrammeView.svelte
+++ b/src/lib/components/DayProgrammeView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getHeroBackgroundStyle } from '$lib/config/heroImages';
 	import Icon from '$lib/components/Icon.svelte';
-	import { dayDetails, abstractUrl, type DayDetail, type DayItem, type Talk } from '$lib/data/programmeDetail';
+	import { dayDetails, abstractUrl, type AbstractRef, type DayDetail, type DayItem, type Talk } from '$lib/data/programmeDetail';
 
 	interface Props {
 		day: DayDetail;
@@ -13,6 +13,9 @@
 	}
 	function isParallel(item: DayItem): item is Extract<DayItem, { kind: 'parallel' }> {
 		return item.kind === 'parallel';
+	}
+	function isLecture(item: DayItem): item is Extract<DayItem, { kind: 'lecture' }> {
+		return item.kind === 'lecture';
 	}
 	function isBlock(item: DayItem): item is Extract<DayItem, { kind: 'registration' | 'break' | 'note' }> {
 		return item.kind === 'registration' || item.kind === 'break' || item.kind === 'note';
@@ -28,10 +31,10 @@
 	<meta name="description" content="Detailed conference programme for {day.label}, {day.date}." />
 </svelte:head>
 
-{#snippet abstractLink(t: Talk)}
-	{#if t.abstract}
+{#snippet abstractLink(ref?: AbstractRef)}
+	{#if ref}
 		<a
-			href={abstractUrl(t.abstract)}
+			href={abstractUrl(ref)}
 			download
 			class="inline-flex items-center gap-1 mt-1 text-sm text-primary hover:underline"
 		>
@@ -136,7 +139,7 @@
 											{#if t.title}
 												<div class="text-base-content/80">{t.title}</div>
 											{/if}
-											{@render abstractLink(t)}
+											{@render abstractLink(t.abstract)}
 										{/if}
 									</div>
 								{/each}
@@ -181,13 +184,33 @@
 														{#if t.title}
 															<div class="text-base-content/80 leading-snug">{t.title}</div>
 														{/if}
-														{@render abstractLink(t)}
+														{@render abstractLink(t.abstract)}
 													</li>
 												{/each}
 											</ul>
 										{/if}
 									</div>
 								{/each}
+							</div>
+						</div>
+					</div>
+				{:else if isLecture(item)}
+					<!-- Summer-school lecture / remarks / panel -->
+					<div class="card bg-base-100 shadow-sm border border-base-300">
+						<div class="card-body p-0">
+							<div class="border-l-4 border-primary px-5 py-4">
+								<div class="font-mono text-xs text-base-content/60">{item.time}</div>
+								<h2 class="text-base font-bold text-primary mt-0.5">{item.label}</h2>
+								{#if item.speaker}
+									<div class="font-semibold mt-0.5">{item.speaker}</div>
+								{/if}
+								{#if item.title}
+									<div class="text-base-content/80">{item.title}</div>
+								{/if}
+								{#if item.note}
+									<div class="text-sm text-base-content/60 mt-0.5">{item.note}</div>
+								{/if}
+								{@render abstractLink(item.abstract)}
 							</div>
 						</div>
 					</div>

--- a/src/lib/data/programme.sync.test.ts
+++ b/src/lib/data/programme.sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { dayDetails } from './programmeDetail';
+import { dayDetails, type Lecture } from './programmeDetail';
 import { days } from './programme';
 
 /**
@@ -47,8 +47,9 @@ for (const day of dayDetails) {
 	}
 }
 
-// Invited-talk blocks from the at-a-glance grid (type 'talk'), limited to days
-// that also exist in the detailed programme (excludes the Summer School day).
+// Invited-talk blocks from the at-a-glance grid (type 'talk'). The Summer School
+// day contributes nothing here — its grid sessions are type 'lecture', cross-checked
+// in the separate describe block below.
 const detailDayKeys = new Set(dayDetails.map((d) => d.date.replace(' 2026', '')));
 const gridTalks = days
 	.filter((d) => detailDayKeys.has(d.date))
@@ -60,10 +61,12 @@ describe('programme grid ↔ detail invited-talk consistency', () => {
 		expect(gridTalks.length).toBeGreaterThan(0);
 	});
 
-	// Every detailed invited talk has a grid block with the same speaker + start time,
-	// and (when the grid shows a subtitle) the detail title appears within it. The grid
-	// may legitimately prepend a prefix (e.g. "… Invited Lecture: <title>"), so we use
-	// containment rather than equality. A reworded title that no longer matches fails.
+	// Every detailed invited talk has a grid block with the same speaker + start time.
+	// When the detail has a real (non-TBC) title, the grid block must also carry it: it
+	// needs a subtitle, and that subtitle must contain the title. The grid may legitimately
+	// prepend a prefix (e.g. "… Invited Lecture: <title>"), so we use containment rather
+	// than equality. A missing subtitle (Ginestra Bianconi's grid block had none while the
+	// detail showed a title + abstract) or a reworded title fails.
 	for (const dt of detailTalks) {
 		const who = `${dt.speaker.split(' (')[0]} — ${dt.day} ${startTime(dt.time)}`;
 		it(`grid has matching block: ${who}`, () => {
@@ -74,9 +77,13 @@ describe('programme grid ↔ detail invited-talk consistency', () => {
 					startTime(g.timeLabel) === startTime(dt.time)
 			);
 			expect(g, `no grid 'talk' block for ${dt.speaker} at ${dt.day} ${dt.time}`).toBeTruthy();
-			if (g?.subtitle && dt.title !== 'TBC') {
+			if (g && dt.title !== 'TBC') {
 				expect(
-					titleKey(g.subtitle).includes(titleKey(dt.title)),
+					g.subtitle,
+					`grid block for ${dt.speaker} (${dt.day} ${startTime(dt.time)}) has no subtitle, but the detail shows a title: "${dt.title}"`
+				).toBeTruthy();
+				expect(
+					titleKey(g.subtitle ?? '').includes(titleKey(dt.title)),
 					`title drift for ${dt.speaker} (${dt.day}):\n  detail: "${dt.title}"\n  grid:   "${g.subtitle}"`
 				).toBe(true);
 			}
@@ -97,6 +104,79 @@ describe('programme grid ↔ detail invited-talk consistency', () => {
 			expect(
 				dt,
 				`grid 'talk' "${g.title}" at ${g.day} ${g.timeLabel} has no detail counterpart`
+			).toBeTruthy();
+		});
+	}
+});
+
+// ===========================================================================
+// Summer School (9 June) is a different projection: the detail page lists each
+// `lecture` as its own item, while the grid stores them as `lecture` grid-sessions
+// (type 'lecture', not 'talk'). The six numbered lectures are duplicated across
+// both files and must agree on start time, speaker, and title — e.g. the coffee
+// break / Lecture 5 retiming must land identically in both, or this fails.
+// ===========================================================================
+
+const SUMMER_DATE = '9 June';
+const summerDetail = dayDetails.find((d) => d.date.replace(' 2026', '') === SUMMER_DATE);
+const summerGrid = days.find((d) => d.date === SUMMER_DATE);
+
+interface DetailLecture {
+	time: string;
+	label: string;
+	speaker: string;
+	title: string;
+}
+
+// Numbered lectures only (label "Lecture N…"): excludes opening/closing remarks and
+// the panel, which the grid renders as separate ceremony/panel blocks.
+const detailLectures: DetailLecture[] = (summerDetail?.items ?? [])
+	.filter((i): i is Lecture => i.kind === 'lecture')
+	.filter((l) => /^lecture\s*\d/i.test(l.label) && !!l.speaker)
+	.map((l) => ({ time: l.time, label: l.label, speaker: l.speaker ?? '', title: l.title ?? '' }));
+
+const gridLectures = (summerGrid?.gridSessions ?? []).filter((s) => s.type === 'lecture');
+
+describe('Summer School (9 June) grid ↔ detail lecture consistency', () => {
+	it('loads the Summer School day from both files with equal lecture counts', () => {
+		expect(summerDetail, "no '9 June' day in programmeDetail.ts").toBeTruthy();
+		expect(summerGrid, "no '9 June' day in programme.ts").toBeTruthy();
+		expect(detailLectures.length).toBeGreaterThan(0);
+		expect(
+			gridLectures.length,
+			`lecture count mismatch — detail: ${detailLectures.length}, grid: ${gridLectures.length}`
+		).toBe(detailLectures.length);
+	});
+
+	// Forward: each detailed lecture has a grid lecture at the same start time,
+	// carrying the same headline (speaker, or activity name for the workshop) and
+	// an agreeing title.
+	for (const dl of detailLectures) {
+		it(`grid has matching lecture: ${dl.label} — ${startTime(dl.time)}`, () => {
+			const g = gridLectures.find((s) => startTime(s.timeLabel) === startTime(dl.time));
+			expect(g, `no grid 'lecture' at 9 June ${dl.time} for ${dl.label}`).toBeTruthy();
+			if (g) {
+				expect(
+					speakerName(g.title),
+					`speaker drift for ${dl.label} (9 June ${startTime(dl.time)}):\n  detail: "${dl.speaker}"\n  grid:   "${g.title}"`
+				).toBe(speakerName(dl.speaker));
+			}
+			if (g?.subtitle && dl.title && dl.title !== 'TBC') {
+				expect(
+					titleKey(g.subtitle).includes(titleKey(dl.title)),
+					`title drift for ${dl.label} (9 June):\n  detail: "${dl.title}"\n  grid:   "${g.subtitle}"`
+				).toBe(true);
+			}
+		});
+	}
+
+	// Reverse: no grid lecture is left without a detail counterpart at the same start.
+	for (const g of gridLectures) {
+		it(`detail has matching lecture: ${g.title} — ${startTime(g.timeLabel)}`, () => {
+			const dl = detailLectures.find((d) => startTime(d.time) === startTime(g.timeLabel));
+			expect(
+				dl,
+				`grid 'lecture' "${g.title}" at 9 June ${g.timeLabel} has no detail counterpart`
 			).toBeTruthy();
 		});
 	}

--- a/src/lib/data/programme.ts
+++ b/src/lib/data/programme.ts
@@ -95,13 +95,13 @@ export const days: DayData[] = [
 			{ startMin: 60, endMin: 70, title: 'Opening Remarks', type: 'ceremony', timeLabel: '09:00 – 09:10' },
 			{ startMin: 70, endMin: 130, title: 'Marton Karsai', subtitle: 'Lecture 1', type: 'lecture', timeLabel: '09:10 – 10:10' },
 			{ startMin: 130, endMin: 150, title: 'Coffee Break', type: 'break', timeLabel: '10:10 – 10:30' },
-			{ startMin: 150, endMin: 210, title: 'Chew Lock Yue', subtitle: 'Lecture 2', type: 'lecture', timeLabel: '10:30 – 11:30' },
+			{ startMin: 150, endMin: 210, title: 'Lock Yue Chew', subtitle: 'Information Thermodynamics: Classical and Quantum Perspective', type: 'lecture', timeLabel: '10:30 – 11:30' },
 			{ startMin: 210, endMin: 270, title: 'Misako Takayasu', subtitle: 'Money-flow network among about 1 million business firms in Japan', type: 'lecture', timeLabel: '11:30 – 12:30' },
 			{ startMin: 270, endMin: 360, title: 'Lunch Break', type: 'break', timeLabel: '12:30 – 14:00' },
 			{ startMin: 360, endMin: 420, title: 'Anirban Chakraborti', subtitle: 'Complex Systems Studies using Machine Learning', type: 'lecture', timeLabel: '14:00 – 15:00' },
-			{ startMin: 420, endMin: 480, title: 'Lecture 5', subtitle: 'Writing, Publishing Strategies, Peer Review Insights', type: 'lecture', timeLabel: '15:00 – 16:00' },
-			{ startMin: 480, endMin: 500, title: 'Coffee Break', type: 'break', timeLabel: '16:00 – 16:20' },
-			{ startMin: 500, endMin: 560, title: 'Jose Fernando Mendes', subtitle: 'Lecture 6', type: 'lecture', timeLabel: '16:20 – 17:20' },
+			{ startMin: 420, endMin: 440, title: 'Coffee Break', type: 'break', timeLabel: '15:00 – 15:20' },
+			{ startMin: 440, endMin: 500, title: 'Academic Publication Workshop', subtitle: 'Writing, Publishing Strategies, Peer Review Insights', type: 'lecture', timeLabel: '15:20 – 16:20' },
+			{ startMin: 500, endMin: 560, title: 'Jose Fernando Mendes', subtitle: 'Navigating Through Complexity: From Emergence to Networks', type: 'lecture', timeLabel: '16:20 – 17:20' },
 			{ startMin: 560, endMin: 585, title: 'Research Directions, Careers, and Interdisciplinary Work', subtitle: 'Panel Discussion + Closing Remarks', type: 'panel', timeLabel: '17:20 – 17:45' }
 		]
 	},
@@ -134,7 +134,7 @@ export const days: DayData[] = [
 		subtitle: 'Conference Day 2',
 		gridSessions: [
 			{ startMin: 0, endMin: 45, title: 'Registration', type: 'registration', timeLabel: '08:00 – 08:45' },
-			{ startMin: 45, endMin: 80, title: 'Ginestra Bianconi', type: 'talk', timeLabel: '08:45 – 09:20' },
+			{ startMin: 45, endMin: 80, title: 'Ginestra Bianconi', subtitle: 'Learning the Topology of Higher-Order Networks from Their Dynamics', type: 'talk', timeLabel: '08:45 – 09:20' },
 			{ startMin: 80, endMin: 125, title: 'Hawoong Jeong', subtitle: 'Understanding Complex Systems via Network, Data, AI', type: 'talk', timeLabel: '09:20 – 10:05' },
 			{ startMin: 125, endMin: 150, title: 'Forging International Collaborations', subtitle: 'Panel Discussion', type: 'panel', timeLabel: '10:05 – 10:30' },
 			{ startMin: 150, endMin: 180, title: 'Coffee Break', type: 'break', timeLabel: '10:30 – 11:00' },

--- a/src/lib/data/programmeDetail.ts
+++ b/src/lib/data/programmeDetail.ts
@@ -8,7 +8,7 @@ export interface Panelist {
 
 // Where an abstract file lives. `type` maps to the static/abstract/<type>/ subfolder,
 // so this extends from invited talks to contributed presentations without changing the schema.
-export type AbstractType = 'invited' | 'presentation';
+export type AbstractType = 'invited' | 'presentation' | 'summer-school';
 
 export interface AbstractRef {
 	type: AbstractType;
@@ -40,6 +40,18 @@ export interface InvitedSession {
 	talks: Talk[];
 }
 
+// A single summer-school timeline entry (lecture, opening/closing remarks, or panel).
+// Rendered as a standalone card; breaks/registration use BlockItem instead.
+export interface Lecture {
+	kind: 'lecture';
+	time: string;
+	label: string; // "Lecture 1", "Opening Remarks", "Panel Discussion / Open Q&A", "Closing Remarks"
+	speaker?: string; // "Marton Karsai (Central European University, Austria)"
+	title?: string; // talk title; "TBC" allowed
+	note?: string; // supporting line, e.g. "Overview of summer school objectives"
+	abstract?: AbstractRef; // downloadable abstract, e.g. { type: 'summer-school', file: 'jose-fernando-mendes.pdf' }
+}
+
 export interface ParallelTrack {
 	name: string;
 	location: string;
@@ -62,10 +74,10 @@ export interface BlockItem {
 	location?: string;
 }
 
-export type DayItem = InvitedSession | ParallelSession | BlockItem;
+export type DayItem = InvitedSession | ParallelSession | BlockItem | Lecture;
 
 export interface DayDetail {
-	slug: '10-june' | '11-june' | '12-june';
+	slug: '9-june' | '10-june' | '11-june' | '12-june';
 	label: string; // weekday
 	shortLabel: string;
 	date: string; // "10 June 2026"
@@ -74,6 +86,36 @@ export interface DayDetail {
 }
 
 export const dayDetails: DayDetail[] = [
+	// =====================================================================
+	{
+		slug: '9-june',
+		label: 'Tuesday',
+		shortLabel: 'Tue',
+		date: '9 June 2026',
+		subtitle: 'Summer School',
+		items: [
+			{ kind: 'registration', time: '08:45 – 09:00', title: 'Registration & Welcome Coffee' },
+			{ kind: 'lecture', time: '09:00 – 09:10', label: 'Opening Remarks', note: 'Overview of summer school objectives' },
+			{ kind: 'lecture', time: '09:10 – 10:10', label: 'Lecture 1', speaker: 'Marton Karsai (Central European University, Austria)', title: 'TBC' },
+			{ kind: 'break', time: '10:10 – 10:30', title: 'Coffee Break' },
+			{ kind: 'lecture', time: '10:30 – 11:30', label: 'Lecture 2', speaker: 'Lock Yue Chew (NTU, Singapore)', title: 'Information Thermodynamics: Classical and Quantum Perspective' },
+			{ kind: 'lecture', time: '11:30 – 12:30', label: 'Lecture 3', speaker: 'Misako Takayasu (Institute of Science Tokyo, Japan)', title: 'Money-Flow Network among About 1 Million Business Firms in Japan' },
+			{ kind: 'break', time: '12:30 – 14:00', title: 'Lunch Break' },
+			{ kind: 'lecture', time: '14:00 – 15:00', label: 'Lecture 4', speaker: 'Anirban Chakraborti (Jawaharlal Nehru University, India)', title: 'Complex Systems Studies using Machine Learning' },
+			{ kind: 'break', time: '15:00 – 15:20', title: 'Coffee Break' },
+			{ kind: 'lecture', time: '15:20 – 16:20', label: 'Lecture 5', speaker: 'Academic Publication Workshop (APW)', title: 'Writing, Publishing Strategies, Peer Review Insights' },
+			{
+				kind: 'lecture',
+				time: '16:20 – 17:20',
+				label: 'Lecture 6',
+				speaker: 'Jose Fernando Mendes (University of Aveiro, Portugal)',
+				title: 'Navigating Through Complexity: From Emergence to Networks',
+				abstract: { type: 'summer-school', file: 'jose-fernando-mendes.pdf' }
+			},
+			{ kind: 'lecture', time: '17:20 – 17:40', label: 'Panel Discussion / Open Q&A', speaker: 'All summer-school speakers (if available)', note: 'Research directions, careers, and interdisciplinary work' },
+			{ kind: 'lecture', time: '17:40 – 17:45', label: 'Closing Remarks' }
+		]
+	},
 	// =====================================================================
 	{
 		slug: '10-june',

--- a/src/routes/programme/9-june/+page.svelte
+++ b/src/routes/programme/9-june/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import DayProgrammeView from '$lib/components/DayProgrammeView.svelte';
+	import { getDay } from '$lib/data/programmeDetail';
+
+	const day = getDay('9-june')!;
+</script>
+
+<DayProgrammeView {day} />

--- a/static/abstract/summer-school/jose-fernando-mendes.pdf
+++ b/static/abstract/summer-school/jose-fernando-mendes.pdf
@@ -1,0 +1,332 @@
+%PDF-1.3
+%ºß¬à
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.2799999999999727 841.8899999999999864]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 3053
+>>
+stream
+0.5670000000000001 w
+0 G
+BT
+/F1 8.5 Tf
+9.7749999999999986 TL
+0.42 0.447 0.502 rg
+62.3622047244094517 773.8585039370078675 Td
+(Asia-Pacific Summer School and Conference on Networks and Complex Systems) Tj
+ET
+BT
+/F1 8.5 Tf
+9.7749999999999986 TL
+0.42 0.447 0.502 rg
+62.3622047244094517 757.7010236220472734 Td
+(Summer School  ·  9 June 2026) Tj
+ET
+0.12 0.25 0.69 RG
+1.7007874015748032 w
+62.3622047244094517 746.3624409448818824 m
+532.9177952755904926 746.3624409448818824 l
+S
+BT
+/F2 10 Tf
+11.5 TL
+0.118 0.251 0.686 rg
+62.3622047244094517 720.8506299212598378 Td
+(LECTURE 6) Tj
+ET
+BT
+/F2 17 Tf
+19.5499999999999972 TL
+0.122 0.161 0.216 rg
+62.3622047244094517 698.1734645669290558 Td
+(Navigating Through Complexity: From Emergence to) Tj
+T* (Networks) Tj
+ET
+BT
+/F1 12 Tf
+13.7999999999999989 TL
+0.118 0.251 0.686 rg
+62.3622047244094517 650.5514173228345953 Td
+(José Fernando Mendes) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0.42 0.447 0.502 rg
+62.3622047244094517 635.8112598425195756 Td
+(University of Aveiro, Portugal) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0.122 0.161 0.216 rg
+62.3622047244094517 604.6301574803148924 Td
+(Abstract) Tj
+ET
+BT
+/F1 11 Tf
+17.0500000000000007 TL
+0.122 0.161 0.216 rg
+1.1987992125984119 Tw
+62.3622047244094517 586.2049606299211746 Td
+(Complex systems are ubiquitous in nature, technology, and society. From ecosystems and the) Tj
+0.3883989501312277 Tw
+0. -17.0500000000000007 Td
+(brain to social interactions, transportation infrastructures, and communication systems, collective) Tj
+0.3577809591982989 Tw
+0. -17.0500000000000007 Td
+(phenomena often emerge from the interactions of many simple components. Understanding how) Tj
+1.3265838885523851 Tw
+0. -17.0500000000000007 Td
+(such emergent behaviors arise remains one of the central challenges of modern science. This) Tj
+0.4303993250843624 Tw
+0. -17.0500000000000007 Td
+(introductory lecture will provide a broad overview of the science of complex systems through the) Tj
+2.7937992125984423 Tw
+0. -17.0500000000000007 Td
+(lens of complex networks. Starting from examples of collective behavior and emergence in) Tj
+0.9288915808600891 Tw
+0. -17.0500000000000007 Td
+(natural and social systems, we will introduce the fundamental concepts of network science and) Tj
+0.309632545931754 Tw
+0. -17.0500000000000007 Td
+(graph theory as a framework for representing and analyzing interacting systems. Basic structural) Tj
+0.8596325459317641 Tw
+0. -17.0500000000000007 Td
+(properties, dynamical processes on networks, and simple yet powerful results will be discussed) Tj
+0.9985590551181212 Tw
+0. -17.0500000000000007 Td
+(intuitively, requiring minimal mathematical background. The lecture will conclude with examples) Tj
+4.0917322834645784 Tw
+0. -17.0500000000000007 Td
+(of applications across diverse disciplines, illustrating how network-based approaches help) Tj
+3.4075590551181105 Tw
+0. -17.0500000000000007 Td
+(uncover common principles underlying complex phenomena and provide valuable tools for) Tj
+0 Tw
+0. -17.0500000000000007 Td
+(understanding real-world systems.) Tj
+ET
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+>>
+endobj
+5 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+6 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+7 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+9 0 obj
+<<
+/Type /Font
+/BaseFont /Courier
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+10 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+11 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+12 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+13 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+14 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+15 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+16 0 obj
+<<
+/Type /Font
+/BaseFont /Times-BoldItalic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+17 0 obj
+<<
+/Type /Font
+/BaseFont /ZapfDingbats
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+18 0 obj
+<<
+/Type /Font
+/BaseFont /Symbol
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+/F2 6 0 R
+/F3 7 0 R
+/F4 8 0 R
+/F5 9 0 R
+/F6 10 0 R
+/F7 11 0 R
+/F8 12 0 R
+/F9 13 0 R
+/F10 14 0 R
+/F11 15 0 R
+/F12 16 0 R
+/F13 17 0 R
+/F14 18 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+19 0 obj
+<<
+/Producer (jsPDF 4.2.1)
+/CreationDate (D:20260605182953+08'00')
+>>
+endobj
+20 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 21
+0000000000 65535 f 
+0000003257 00000 n 
+0000005074 00000 n 
+0000000015 00000 n 
+0000000152 00000 n 
+0000003314 00000 n 
+0000003439 00000 n 
+0000003569 00000 n 
+0000003702 00000 n 
+0000003839 00000 n 
+0000003962 00000 n 
+0000004091 00000 n 
+0000004223 00000 n 
+0000004359 00000 n 
+0000004487 00000 n 
+0000004614 00000 n 
+0000004743 00000 n 
+0000004876 00000 n 
+0000004978 00000 n 
+0000005322 00000 n 
+0000005408 00000 n 
+trailer
+<<
+/Size 21
+/Root 20 0 R
+/Info 19 0 R
+/ID [ <E084641537088086C71DB139D7CDC070> <E084641537088086C71DB139D7CDC070> ]
+>>
+startxref
+5512
+%%EOF


### PR DESCRIPTION
## Summary
Surfaces the **Summer School (9 June)** as a detailed programme day, reusing the existing **"Download abstract"** link rather than adding any inline-abstract UI. José Fernando Mendes' Lecture 6 ships a pre-made, brand-styled abstract PDF.

## Changes
- **`programmeDetail.ts`** — new `Lecture` item kind + the `9-june` day; `summer-school` added to `AbstractType`. Lecture 6 links the PDF.
- **`DayProgrammeView.svelte`** — lecture cards rendered with the time top-left (matching the invited-talk rows); the abstract snippet now takes an `AbstractRef`, so lectures and talks share one "Download abstract" link.
- **`programme.ts`** — reconcile the at-a-glance grid with the lecture times/titles (coffee break / Lecture 5 retiming, Lecture 2 + 6 titles, APW headline) and add **Ginestra Bianconi's** missing talk title.
- **`static/abstract/summer-school/jose-fernando-mendes.pdf`** — the pre-made abstract.
- **`programme.sync.test.ts`** — cross-checks the Summer School grid ↔ detail lectures (speaker, start time, title, both directions), and **tightens** the invited-talk check to fail when the grid omits a title the detail shows (the gap that hid Ginestra's missing subtitle).

## Testing
- `npm run check` — 0 errors, 0 warnings
- `npm test` — **40/40** pass
- Verified each new guard bites (drift injection → failure → restore) for José's title, Lecture 5's speaker, and Ginestra's missing subtitle.

> Note: this branch is based on `origin/main` and supersedes the older `claude/invited-speaker-abstracts` branch (which `main` already re-did as separate commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)