### PR TITLE
Programme booklet PDF + build-time static PDFs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+# Runs on pull requests (the deploy workflow only runs on push to main, so PRs
+# would otherwise have no checks). Type-checks, tests, and builds — the build
+# step also exercises the prerendered PDF endpoints.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Type check
+        run: npm run check
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"jspdf": "^4.2.1",
-				"lucide-svelte": "^0.539.0"
+				"lucide-svelte": "^0.539.0",
+				"qrcode": "^1.5.4"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^6.0.0",
@@ -17,6 +18,7 @@
 				"@sveltejs/kit": "^2.22.0",
 				"@sveltejs/vite-plugin-svelte": "^6.0.0",
 				"@tailwindcss/typography": "^0.5.16",
+				"@types/qrcode": "^1.5.6",
 				"autoprefixer": "^10.4.21",
 				"daisyui": "^5.0.50",
 				"postcss": "^8.5.6",
@@ -1061,11 +1063,31 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": ">=7.24.0 <7.24.7"
+			}
+		},
 		"node_modules/@types/pako": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
 			"integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
 			"license": "MIT"
+		},
+		"node_modules/@types/qrcode": {
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+			"integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/raf": {
 			"version": "3.4.3",
@@ -1425,6 +1447,15 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1502,6 +1533,87 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1515,7 +1627,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -1528,7 +1639,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/commander": {
@@ -1636,6 +1746,15 @@
 				}
 			}
 		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1671,6 +1790,12 @@
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/dijkstrajs": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+			"license": "MIT"
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
@@ -1892,6 +2017,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1946,6 +2084,15 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/glob": {
@@ -2058,7 +2205,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -2435,6 +2581,18 @@
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
 			"license": "MIT"
 		},
+		"node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/lodash.castarray": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
@@ -2660,6 +2818,42 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2672,6 +2866,15 @@
 			"resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
 			"integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
 			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
@@ -2759,6 +2962,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pngjs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+			"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -2911,6 +3123,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/qrcode": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+			"integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"dijkstrajs": "^1.0.1",
+				"pngjs": "^5.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"qrcode": "bin/qrcode"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2972,6 +3201,21 @@
 			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"license": "ISC"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
@@ -3091,6 +3335,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"license": "ISC"
 		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.1",
@@ -3623,6 +3873,13 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -3872,6 +4129,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"license": "ISC"
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3987,6 +4250,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"license": "ISC"
+		},
 		"node_modules/yaml": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
@@ -3998,6 +4267,82 @@
 			},
 			"engines": {
 				"node": ">= 14.6"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/zimmerframe": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
 		"@tailwindcss/typography": "^0.5.16",
+		"@types/qrcode": "^1.5.6",
 		"autoprefixer": "^10.4.21",
 		"daisyui": "^5.0.50",
 		"postcss": "^8.5.6",
@@ -31,6 +32,7 @@
 	},
 	"dependencies": {
 		"jspdf": "^4.2.1",
-		"lucide-svelte": "^0.539.0"
+		"lucide-svelte": "^0.539.0",
+		"qrcode": "^1.5.4"
 	}
 }

--- a/src/lib/config/brandColors.ts
+++ b/src/lib/config/brandColors.ts
@@ -1,0 +1,16 @@
+// Brand colours for the generated PDFs. jsPDF needs numeric RGB (it can't read CSS
+// variables), and the PDFs are generated at build time in Node where no DOM exists —
+// so these live here as plain constants rather than being read from CSS at runtime.
+//
+// These mirror the colours the WEBSITE actually renders: the DaisyUI v5 "light" theme
+// (converted from its oklch() values to sRGB). Note that the --p/--s/--a overrides in
+// src/app.css are DaisyUI v4 syntax and are ignored by v5, so the site falls back to
+// these defaults — the booklet is matched to them so print and web stay consistent.
+// To recolour, change these values (and define a real DaisyUI v5 theme if you also
+// want the website to change).
+
+export type RGB = [number, number, number];
+
+export const PRIMARY: RGB = [66, 42, 213]; // #422ad5 blue-purple — DaisyUI primary (invited sessions / lectures)
+export const SECONDARY: RGB = [244, 48, 152]; // #f43098 pink      — DaisyUI secondary (parallel sessions)
+export const ACCENT: RGB = [0, 211, 187]; // #00d3bb teal          — DaisyUI accent

--- a/src/lib/utils/programmeBookletPdf.ts
+++ b/src/lib/utils/programmeBookletPdf.ts
@@ -1,0 +1,407 @@
+import { jsPDF } from 'jspdf';
+import QRCode from 'qrcode';
+import { PRIMARY, SECONDARY, type RGB } from '$lib/config/brandColors';
+import {
+	dayDetails,
+	abstractUrl,
+	type AbstractRef,
+	type DayDetail,
+	type Talk
+} from '$lib/data/programmeDetail';
+
+// Full "programme details" booklet — a flowing, paginated A5 document that mirrors
+// the /programme/<day> detail pages (DayProgrammeView.svelte). Distinct from the
+// at-a-glance grid in programmePdf.ts. Each talk that has a downloadable abstract
+// gets a small QR code linking to the hosted file, so the booklet stays printable
+// while abstracts (binary .docx/.pdf) remain online.
+
+// PRIMARY (invited sessions / lectures) and SECONDARY (parallel sessions) come from
+// src/lib/config/brandColors.ts — edit there to recolour. Neutrals stay local.
+const INK: RGB = [31, 41, 55]; // base-content (gray-800)
+const MUTED: RGB = [107, 114, 128]; // gray-500
+const FAINT: RGB = [156, 163, 175]; // gray-400
+const LINE: RGB = [209, 213, 219]; // gray-300
+const BLOCK_BG: RGB = [243, 244, 246]; // base-200 (gray-100)
+const WHITE: RGB = [255, 255, 255];
+
+// A5 portrait, in mm.
+const PAGE_W = 148;
+const PAGE_H = 210;
+const MARGIN = 10;
+const CONTENT_X = MARGIN;
+const CONTENT_W = PAGE_W - MARGIN * 2;
+const TOP = MARGIN;
+const BOTTOM = PAGE_H - 9; // leave room for the footer
+
+const QR_SIZE = 13; // mm
+
+// Printed QR codes must resolve to the live site, so we hardcode the production
+// origin — that way the booklet is correct even when generated from localhost or a
+// preview build. This is the GitHub Pages site origin (where static/abstract/* is
+// served); it is NOT the registration backend (VITE_API_BASE_URL). Update only if
+// the site moves to a custom domain. Set to '' to fall back to window.location.origin.
+const SITE_BASE_URL = 'https://apcncs2026.github.io';
+
+function siteOrigin(): string {
+	if (SITE_BASE_URL) return SITE_BASE_URL.replace(/\/+$/, '');
+	if (typeof window !== 'undefined') return window.location.origin;
+	return '';
+}
+
+// pt -> mm, and a comfortable line height for a given point size.
+const ptToMm = (pt: number) => pt * 0.352777;
+const lh = (size: number) => ptToMm(size) * 1.18;
+
+// ==================== QR pre-generation ====================
+// jsPDF draws synchronously but QR generation is async, so build every data URL
+// up front, then render in one synchronous pass.
+
+function collectAbstractRefs(): AbstractRef[] {
+	const refs: AbstractRef[] = [];
+	for (const day of dayDetails) {
+		for (const item of day.items) {
+			if (item.kind === 'invited') {
+				for (const t of item.talks) if (t.abstract) refs.push(t.abstract);
+			} else if (item.kind === 'parallel') {
+				for (const tr of item.tracks) for (const t of tr.talks) if (t.abstract) refs.push(t.abstract);
+			} else if (item.kind === 'lecture') {
+				if (item.abstract) refs.push(item.abstract);
+			}
+		}
+	}
+	return refs;
+}
+
+async function buildQrMap(origin: string): Promise<Map<string, string>> {
+	const map = new Map<string, string>();
+	const urls = new Set(collectAbstractRefs().map((ref) => origin + abstractUrl(ref)));
+	await Promise.all(
+		[...urls].map(async (url) => {
+			map.set(url, await QRCode.toDataURL(url, { margin: 0, width: 160, errorCorrectionLevel: 'M' }));
+		})
+	);
+	return map;
+}
+
+// ==================== Renderer ====================
+
+interface Seg {
+	txt: string;
+	font: 'normal' | 'bold' | 'italic';
+	size: number;
+	color: RGB;
+	gap: number; // extra mm after this segment
+}
+
+export async function buildProgrammeBookletDoc(): Promise<jsPDF> {
+	const origin = siteOrigin();
+	const qrMap = await buildQrMap(origin);
+	const coverQr = await QRCode.toDataURL(origin + '/programme', {
+		margin: 0,
+		width: 200,
+		errorCorrectionLevel: 'M'
+	});
+
+	// compress: deflate content/image streams — without it the ~75 QR PNGs balloon
+	// the file to several MB (jsPDF stores bitmaps uncompressed otherwise).
+	const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a5', compress: true });
+	let y = TOP;
+
+	// When a session card spills onto a new page, redraw a small "(cont.)" header
+	// so a stranded talk still has context.
+	let continuation: (() => void) | null = null;
+
+	const newPage = () => {
+		doc.addPage();
+		y = TOP;
+		if (continuation) continuation();
+	};
+	const ensure = (h: number) => {
+		if (y + h > BOTTOM) newPage();
+	};
+
+	// ---- generic text block with optional left stripe and right-hand QR ----
+	function drawSegBlock(segs: Seg[], accent: RGB, stripe: boolean, qrUrl?: string) {
+		const qr = qrUrl ? qrMap.get(qrUrl) : undefined;
+		const padL = stripe ? 4 : 2;
+		const textX = CONTENT_X + padL;
+		const textRight = CONTENT_X + CONTENT_W - 1 - (qr ? QR_SIZE + 2 : 0);
+		const textW = textRight - textX;
+
+		// Measure (wrapping depends on the active font size).
+		const wrapped: { lines: string[]; size: number; font: Seg['font']; color: RGB; gap: number }[] = [];
+		let textH = 0;
+		for (const s of segs) {
+			doc.setFont('helvetica', s.font);
+			doc.setFontSize(s.size);
+			const lines = doc.splitTextToSize(s.txt, textW) as string[];
+			wrapped.push({ lines, size: s.size, font: s.font, color: s.color, gap: s.gap });
+			textH += lines.length * lh(s.size) + s.gap;
+		}
+		const qrH = qr ? QR_SIZE + 2.5 : 0;
+		const blockH = Math.max(textH, qrH) + 3;
+
+		ensure(blockH);
+		const top = y;
+
+		if (stripe) {
+			doc.setFillColor(...accent);
+			doc.rect(CONTENT_X + 1, top + 0.5, 1.2, blockH - 1, 'F');
+		}
+
+		let ty = top + ptToMm(wrapped[0]?.size ?? 8) + 1;
+		for (const w of wrapped) {
+			doc.setFont('helvetica', w.font);
+			doc.setFontSize(w.size);
+			doc.setTextColor(...w.color);
+			for (const ln of w.lines) {
+				doc.text(ln, textX, ty);
+				ty += lh(w.size);
+			}
+			ty += w.gap;
+		}
+
+		if (qr) {
+			const qx = CONTENT_X + CONTENT_W - QR_SIZE - 1;
+			doc.addImage(qr, 'PNG', qx, top + 1, QR_SIZE, QR_SIZE);
+			doc.setFont('helvetica', 'normal');
+			doc.setFontSize(5);
+			doc.setTextColor(...MUTED);
+			doc.text('Abstract', qx + QR_SIZE / 2, top + 1 + QR_SIZE + 2, { align: 'center' });
+		}
+
+		y = top + blockH;
+	}
+
+	// ---- talk (invited list item or parallel-track list item) ----
+	function drawTalk(t: Talk, opts: { stripe: boolean; accent: RGB }) {
+		const segs: Seg[] = [{ txt: t.time, font: 'normal', size: 6.5, color: MUTED, gap: 0.6 }];
+		const header = t.prefix ? t.prefix + (t.panelTitle ? `: ${t.panelTitle}` : '') : (t.panelTitle ?? '');
+		if (header) segs.push({ txt: header, font: 'bold', size: 7.5, color: opts.accent, gap: 0.6 });
+
+		if (t.panelists) {
+			for (const p of t.panelists)
+				segs.push({
+					txt: `•  ${p.name}${p.note ? ` (${p.note})` : ''}`,
+					font: 'normal',
+					size: 7.5,
+					color: INK,
+					gap: 0.4
+				});
+			if (t.moderator)
+				segs.push({ txt: `Moderator: ${t.moderator}`, font: 'normal', size: 7.5, color: MUTED, gap: 0 });
+		} else {
+			if (t.speaker) segs.push({ txt: t.speaker, font: 'bold', size: 8, color: INK, gap: 0.4 });
+			if (t.title) segs.push({ txt: t.title, font: 'normal', size: 7.5, color: INK, gap: 0 });
+		}
+
+		const qrUrl = t.abstract ? origin + abstractUrl(t.abstract) : undefined;
+		drawSegBlock(segs, opts.accent, opts.stripe, qrUrl);
+	}
+
+	// ---- coloured session header bar ----
+	function drawSessionHeader(title: string, time: string, meta: string[], accent: RGB) {
+		const barH = meta.length ? 11 : 8;
+		ensure(barH + 10); // keep the header with at least the start of its first talk
+		doc.setFillColor(...accent);
+		doc.roundedRect(CONTENT_X, y, CONTENT_W, barH, 1.2, 1.2, 'F');
+		doc.setTextColor(...WHITE);
+		doc.setFont('helvetica', 'bold');
+		doc.setFontSize(9.5);
+		doc.text(title, CONTENT_X + 3, y + 5);
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(7.5);
+		doc.text(time, CONTENT_X + CONTENT_W - 3, y + 5, { align: 'right' });
+		if (meta.length) {
+			doc.setFontSize(6.8);
+			doc.text(meta.join('     '), CONTENT_X + 3, y + 9);
+		}
+		y += barH + 2;
+		const headerTitle = title;
+		const headerAccent = accent;
+		continuation = () => {
+			doc.setFillColor(...headerAccent);
+			doc.roundedRect(CONTENT_X, y, CONTENT_W, 6, 1, 1, 'F');
+			doc.setTextColor(...WHITE);
+			doc.setFont('helvetica', 'bold');
+			doc.setFontSize(7.5);
+			doc.text(`${headerTitle} (cont.)`, CONTENT_X + 3, y + 4);
+			y += 8;
+		};
+	}
+
+	function drawTrackHeader(name: string, meta: string[]) {
+		ensure(11);
+		doc.setFont('helvetica', 'bold');
+		doc.setFontSize(8.5);
+		doc.setTextColor(...SECONDARY);
+		const lines = doc.splitTextToSize(name, CONTENT_W - 4) as string[];
+		let ty = y + ptToMm(8.5) + 0.5;
+		for (const ln of lines) {
+			doc.text(ln, CONTENT_X + 2, ty);
+			ty += lh(8.5);
+		}
+		y = ty - lh(8.5) + 1.5;
+		if (meta.length) {
+			doc.setFont('helvetica', 'normal');
+			doc.setFontSize(6.8);
+			doc.setTextColor(...MUTED);
+			doc.text(meta.join('     '), CONTENT_X + 2, y + 2.5);
+			y += 4;
+		}
+		doc.setDrawColor(...LINE);
+		doc.setLineWidth(0.2);
+		doc.line(CONTENT_X + 2, y + 1, CONTENT_X + CONTENT_W - 2, y + 1);
+		y += 2.5;
+	}
+
+	function drawBlock(time: string, title: string, location?: string) {
+		const h = 7;
+		ensure(h + 2);
+		doc.setFillColor(...BLOCK_BG);
+		doc.roundedRect(CONTENT_X, y, CONTENT_W, h, 1, 1, 'F');
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(7);
+		doc.setTextColor(...MUTED);
+		doc.text(time, CONTENT_X + 3, y + 4.4);
+		doc.setFont('helvetica', 'bold');
+		doc.setFontSize(8);
+		doc.setTextColor(...INK);
+		doc.text(title, CONTENT_X + 30, y + 4.4);
+		if (location) {
+			doc.setFont('helvetica', 'normal');
+			doc.setFontSize(6.8);
+			doc.setTextColor(...MUTED);
+			doc.text(location, CONTENT_X + CONTENT_W - 3, y + 4.4, { align: 'right' });
+		}
+		y += h + 2.5;
+	}
+
+	function drawDayHeader(day: DayDetail) {
+		const h = 13;
+		doc.setFillColor(...PRIMARY);
+		doc.roundedRect(CONTENT_X, y, CONTENT_W, h, 1.5, 1.5, 'F');
+		doc.setTextColor(...WHITE);
+		doc.setFont('helvetica', 'bold');
+		doc.setFontSize(12);
+		doc.text(`${day.label}, ${day.date}`, CONTENT_X + 4, y + 6);
+		doc.setFont('helvetica', 'normal');
+		doc.setFontSize(8.5);
+		doc.text(day.subtitle, CONTENT_X + 4, y + 10.5);
+		y += h + 3.5;
+	}
+
+	// ---- cover ----
+	doc.setTextColor(...PRIMARY);
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(26);
+	doc.text('APCNCS 2026', PAGE_W / 2, 48, { align: 'center' });
+
+	doc.setTextColor(...INK);
+	doc.setFont('helvetica', 'normal');
+	doc.setFontSize(11);
+	const fullName = doc.splitTextToSize(
+		'Asia-Pacific Summer School and Conference on Networks and Complex Systems',
+		CONTENT_W - 6
+	) as string[];
+	let cy = 62;
+	for (const ln of fullName) {
+		doc.text(ln, PAGE_W / 2, cy, { align: 'center' });
+		cy += 6;
+	}
+
+	doc.setFont('helvetica', 'bold');
+	doc.setFontSize(13);
+	doc.setTextColor(...SECONDARY);
+	doc.text('Programme', PAGE_W / 2, cy + 6, { align: 'center' });
+
+	doc.setFont('helvetica', 'normal');
+	doc.setFontSize(10);
+	doc.setTextColor(...MUTED);
+	doc.text('9 – 12 June 2026', PAGE_W / 2, cy + 16, { align: 'center' });
+	doc.text('Nanyang Technological University, Singapore', PAGE_W / 2, cy + 22, { align: 'center' });
+
+	const coverQrSize = 30;
+	doc.addImage(coverQr, 'PNG', (PAGE_W - coverQrSize) / 2, cy + 34, coverQrSize, coverQrSize);
+	doc.setFontSize(7);
+	doc.setTextColor(...MUTED);
+	doc.text('Scan for the online programme', PAGE_W / 2, cy + 34 + coverQrSize + 4, {
+		align: 'center'
+	});
+
+	// ---- days ----
+	for (const day of dayDetails) {
+		doc.addPage();
+		y = TOP;
+		continuation = null;
+		drawDayHeader(day);
+
+		for (const item of day.items) {
+			if (item.kind === 'registration' || item.kind === 'break' || item.kind === 'note') {
+				continuation = null;
+				drawBlock(item.time, item.title, item.location);
+			} else if (item.kind === 'invited') {
+				const meta = [`Room: ${item.location}`];
+				if (item.chair) meta.push(`Chair: ${item.chair}`);
+				drawSessionHeader(`Invited Session ${item.number}`, item.time, meta, PRIMARY);
+				for (const t of item.talks) drawTalk(t, { stripe: true, accent: PRIMARY });
+				y += 2;
+				continuation = null;
+			} else if (item.kind === 'parallel') {
+				const title = item.title ?? `Parallel Session ${item.number}`;
+				drawSessionHeader(title, item.time, item.note ? [item.note] : [], SECONDARY);
+				for (const track of item.tracks) {
+					const meta = [`Room: ${track.location}`];
+					if (track.chair) meta.push(`Chair: ${track.chair}`);
+					drawTrackHeader(track.name, meta);
+					if (track.tba) {
+						doc.setFont('helvetica', 'italic');
+						doc.setFontSize(7.5);
+						doc.setTextColor(...MUTED);
+						doc.text('Programme to be announced.', CONTENT_X + 2, y + 3);
+						y += 6;
+					} else {
+						for (const t of track.talks) drawTalk(t, { stripe: false, accent: SECONDARY });
+					}
+					y += 1.5;
+				}
+				y += 2;
+				continuation = null;
+			} else if (item.kind === 'lecture') {
+				const segs: Seg[] = [{ txt: item.time, font: 'normal', size: 6.5, color: MUTED, gap: 0.6 }];
+				segs.push({ txt: item.label, font: 'bold', size: 8.5, color: PRIMARY, gap: 0.5 });
+				if (item.speaker) segs.push({ txt: item.speaker, font: 'bold', size: 8, color: INK, gap: 0.4 });
+				if (item.title) segs.push({ txt: item.title, font: 'normal', size: 7.5, color: INK, gap: 0.4 });
+				if (item.tutors)
+					segs.push({ txt: `Tutors: ${item.tutors}`, font: 'normal', size: 7, color: MUTED, gap: 0.3 });
+				if (item.note)
+					segs.push({ txt: item.note, font: 'normal', size: 7, color: MUTED, gap: 0 });
+				const qrUrl = item.abstract ? origin + abstractUrl(item.abstract) : undefined;
+				continuation = null;
+				drawSegBlock(segs, PRIMARY, true, qrUrl);
+				y += 1.5;
+			}
+		}
+	}
+
+	// ---- footers + page numbers (cover excluded) ----
+	const pages = doc.getNumberOfPages();
+	for (let i = 2; i <= pages; i++) {
+		doc.setPage(i);
+		doc.setDrawColor(...LINE);
+		doc.setLineWidth(0.2);
+		doc.line(CONTENT_X, PAGE_H - 7, CONTENT_X + CONTENT_W, PAGE_H - 7);
+		doc.setFont('helvetica', 'italic');
+		doc.setFontSize(6);
+		doc.setTextColor(...FAINT);
+		doc.text('APCNCS 2026  •  Programme is subject to change.', CONTENT_X, PAGE_H - 4);
+		doc.text(`${i - 1}`, CONTENT_X + CONTENT_W, PAGE_H - 4, { align: 'right' });
+	}
+
+	return doc;
+}
+
+export async function generateProgrammeBookletPDF() {
+	const doc = await buildProgrammeBookletDoc();
+	doc.save('APCNCS-2026-Programme-Booklet.pdf');
+}

--- a/src/lib/utils/programmePdf.ts
+++ b/src/lib/utils/programmePdf.ts
@@ -1,4 +1,4 @@
-import jsPDF from 'jspdf';
+import { jsPDF } from 'jspdf';
 import { days, sessionTypeConfig, allSessionTypes, realToVirtual, GRID_VIRTUAL_END, type SessionType, type DayData } from '$lib/data/programme';
 
 type RGB = [number, number, number];
@@ -229,7 +229,7 @@ function drawFooter(doc: jsPDF, pageW: number, footerY: number) {
 
 // ==================== Landscape: 1 page, 4 columns ====================
 
-export function generateProgrammePDF() {
+export function buildProgrammeDoc(): jsPDF {
 	const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
 	const pageW = 297, pageH = 210, margin = 5;
 
@@ -267,12 +267,16 @@ export function generateProgrammePDF() {
 	doc.rect(margin, dayHeaderY, pageW - margin * 2, gridEndY - dayHeaderY);
 
 	drawFooter(doc, pageW, footerY + 1);
-	doc.save('APCNCS-2026-Programme.pdf');
+	return doc;
+}
+
+export function generateProgrammePDF() {
+	buildProgrammeDoc().save('APCNCS-2026-Programme.pdf');
 }
 
 // ==================== Portrait: 2 pages, 2 columns each ====================
 
-export function generateProgrammePDFPortrait() {
+export function buildProgrammePortraitDoc(): jsPDF {
 	const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
 	const pageW = 210, pageH = 297, margin = 8;
 	const dayPairs = [[days[0], days[1]], [days[2], days[3]]];
@@ -317,7 +321,11 @@ export function generateProgrammePDFPortrait() {
 		drawFooter(doc, pageW, footerY + 1);
 	}
 
-	doc.save('APCNCS-2026-Programme.pdf');
+	return doc;
+}
+
+export function generateProgrammePDFPortrait() {
+	buildProgrammePortraitDoc().save('APCNCS-2026-Programme.pdf');
 }
 
 function truncateText(doc: jsPDF, text: string, maxW: number): string {

--- a/src/routes/programme/+page.svelte
+++ b/src/routes/programme/+page.svelte
@@ -29,10 +29,8 @@
 		return (realToVirtual(s.endMin) - realToVirtual(s.startMin)) * SCALE - GAP * 2;
 	}
 
-	async function handleDownloadPDF(portrait = false) {
-		const mod = await import('$lib/utils/programmePdf');
-		portrait ? mod.generateProgrammePDFPortrait() : mod.generateProgrammePDF();
-	}
+	// PDFs are prerendered to static files at build time (see the +server.ts routes
+	// under /programme), so these are plain download links — no client-side jsPDF.
 </script>
 
 <svelte:head>
@@ -69,16 +67,20 @@
 
 	<!-- PDF downloads -->
 	<section class="py-5 px-4 bg-base-200">
-		<div class="max-w-7xl mx-auto">
-			<div class="flex flex-wrap gap-x-4 gap-y-2 justify-center">
-				<button onclick={() => handleDownloadPDF(false)} class="btn btn-outline btn-lg gap-2 shrink-0">
+		<div class="max-w-7xl mx-auto flex flex-col items-center gap-3">
+			<a href="/programme/booklet.pdf" download="APCNCS-2026-Programme-Booklet.pdf" class="btn btn-primary btn-lg gap-2 shrink-0">
+				<Icon name="file-text" class_="w-5 h-5" />
+				Full Programme Booklet (PDF)
+			</a>
+			<div class="flex flex-wrap gap-x-4 gap-y-2 justify-center items-center">
+				<a href="/programme/at-a-glance-landscape.pdf" download="APCNCS-2026-Programme-Landscape.pdf" class="btn btn-outline btn-md gap-2 shrink-0">
 					<Icon name="file-down" class_="w-4 h-4" />
-					PDF (Landscape)
-				</button>
-				<button onclick={() => handleDownloadPDF(true)} class="btn btn-outline btn-lg gap-2 shrink-0">
+					Timetable (Landscape)
+				</a>
+				<a href="/programme/at-a-glance-portrait.pdf" download="APCNCS-2026-Programme-Portrait.pdf" class="btn btn-outline btn-md gap-2 shrink-0">
 					<Icon name="file-down" class_="w-4 h-4" />
-					PDF (Portrait)
-				</button>
+					Timetable (Portrait)
+				</a>
 			</div>
 		</div>
 	</section>

--- a/src/routes/programme/at-a-glance-landscape.pdf/+server.ts
+++ b/src/routes/programme/at-a-glance-landscape.pdf/+server.ts
@@ -1,0 +1,14 @@
+import { buildProgrammeDoc } from '$lib/utils/programmePdf';
+
+// Prerendered to build/programme/at-a-glance-landscape.pdf at build time.
+export const prerender = true;
+
+export function GET() {
+	const bytes = buildProgrammeDoc().output('arraybuffer');
+	return new Response(bytes, {
+		headers: {
+			'Content-Type': 'application/pdf',
+			'Content-Disposition': 'inline; filename="APCNCS-2026-Programme-Landscape.pdf"'
+		}
+	});
+}

--- a/src/routes/programme/at-a-glance-portrait.pdf/+server.ts
+++ b/src/routes/programme/at-a-glance-portrait.pdf/+server.ts
@@ -1,0 +1,14 @@
+import { buildProgrammePortraitDoc } from '$lib/utils/programmePdf';
+
+// Prerendered to build/programme/at-a-glance-portrait.pdf at build time.
+export const prerender = true;
+
+export function GET() {
+	const bytes = buildProgrammePortraitDoc().output('arraybuffer');
+	return new Response(bytes, {
+		headers: {
+			'Content-Type': 'application/pdf',
+			'Content-Disposition': 'inline; filename="APCNCS-2026-Programme-Portrait.pdf"'
+		}
+	});
+}

--- a/src/routes/programme/booklet.pdf/+server.ts
+++ b/src/routes/programme/booklet.pdf/+server.ts
@@ -1,0 +1,17 @@
+import { buildProgrammeBookletDoc } from '$lib/utils/programmeBookletPdf';
+
+// Prerendered at build time: adapter-static writes the bytes to
+// build/programme/booklet.pdf, served as a static file. Regenerated on every
+// deploy, so it stays in sync with the programme data.
+export const prerender = true;
+
+export async function GET() {
+	const doc = await buildProgrammeBookletDoc();
+	const bytes = doc.output('arraybuffer');
+	return new Response(bytes, {
+		headers: {
+			'Content-Type': 'application/pdf',
+			'Content-Disposition': 'inline; filename="APCNCS-2026-Programme-Booklet.pdf"'
+		}
+	});
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -17,7 +17,16 @@ const config = {
 			fallback: undefined,
 			precompress: false,
 			strict: true
-		})
+		}),
+		prerender: {
+			// Crawl all pages, plus explicitly emit the build-time PDF endpoints.
+			entries: [
+				'*',
+				'/programme/booklet.pdf',
+				'/programme/at-a-glance-landscape.pdf',
+				'/programme/at-a-glance-portrait.pdf'
+			]
+		}
 	}
 };
 


### PR DESCRIPTION
## Summary
Adds a printable **A5 programme booklet** and serves all three programme PDFs as **pre-generated static files** instead of generating them in the browser.

## What's new
- **Full Programme Booklet** (`src/lib/utils/programmeBookletPdf.ts`): a flowing A5 PDF mirroring the `/programme/<day>` detail pages — cover + one page per day, invited/parallel/lecture cards, panels, and a **QR code per talk** linking to its hosted abstract (`/abstract/...`). Cover QR links to the online programme.
- **Build-time static PDFs**: three prerendered `+server.ts` endpoints under `/programme` run jsPDF at build time; `adapter-static` writes `booklet.pdf`, `at-a-glance-landscape.pdf`, `at-a-glance-portrait.pdf`. The buttons are now plain `<a download>` links with explicit filenames (`APCNCS-2026-Programme-*.pdf`). jsPDF/qrcode no longer ship to the client.
- **Centralized brand colours** (`src/lib/config/brandColors.ts`) — matched to the DaisyUI v5 light theme the site actually renders (blue-purple/pink), so the booklet matches the web pages.

## Notes
- `programmePdf.ts` was split into `build*Doc()` (used by the endpoints) + thin `generate*()` save-wrappers.
- The deploy workflow already rebuilds on pushes to `src/**`, so the PDFs auto-regenerate and stay in sync with the programme data.
- QR codes point to `https://apcncs2026.github.io` (hardcoded in the booklet util) so print output is correct regardless of where it's generated.

## Verification
- `npm run check` — 0 errors / 0 warnings
- `npm test` — 40 passed
- `npm run build` — all three PDFs emitted as valid `%PDF-` files; client bundle has 0 jsPDF/qrcode references
- Rendered booklet pages to confirm colours match the website

🤖 Generated with [Claude Code](https://claude.com/claude-code)
